### PR TITLE
add tutorial/04-logic/06-await-blocks in Japanese

### DIFF
--- a/content/tutorial/04-logic/06-await-blocks/text.ja.md
+++ b/content/tutorial/04-logic/06-await-blocks/text.ja.md
@@ -1,0 +1,27 @@
+---
+title: Await blocks
+---
+
+ほとんどの webアプリケーションでは、どこかの時点で非同期のデータを扱わなければなりません。
+Svelte ではマークアップの中で直接 [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) の値
+を簡単に *await* することができます。
+
+```html
+{#await promise}
+	<p>...waiting</p>
+{:then number}
+	<p>The number is {number}</p>
+{:catch error}
+	<p style="color: red">{error.message}</p>
+{/await}
+```
+
+> 直近の `promise` だけが処理されるので、他の非同期処理の状態を気にする必要はありません。
+
+promise が reject できないことがわかっている場合は、`catch` ブロックを省略することができます。また promise が resolve するまで何も表示したくない場合は、最初のブロックを省略することもできます。
+
+```html
+{#await promise then value}
+	<p>the value is {value}</p>
+{/await}
+```


### PR DESCRIPTION
#17 

> Only the most recent promise is considered, meaning you don't need to worry about race conditions.

上記の英文を

> 直近の `promise` だけが処理されるので、他の非同期処理の状態を気にする必要はありません。

こういう日本語訳にするのは結構な意訳ともいえるのですが、

要するにテンプレートで監視しているものとは別の promise が並列で走っていて、
先にそちらの方が resolve とかしちゃっても間違って適用されたりはしない

ということを言いたいのだと思うので、こういう訳文にしてみました。

